### PR TITLE
Fix 외부 영역 클릭시 모달이 닫히도록 수정

### DIFF
--- a/src/components/modal/MiniModalWindow.jsx
+++ b/src/components/modal/MiniModalWindow.jsx
@@ -1,9 +1,9 @@
 import * as S from "../../styles/MiniModalWindowStyle";
 
-const MiniModalWindow = ({openMiniModalHandler}) => {
+const MiniModalWindow = ({ openMiniModalHandler }) => {
     return (
-        <div onClick={openMiniModalHandler}>
-            <S.ModalDiv></S.ModalDiv>
+        <div>
+            <S.ModalDiv onClick={openMiniModalHandler}></S.ModalDiv>
             <S.ModalComponents>
                 <div>닫기 버튼 1개가 있고,<br />외부 영역을 누르면 모달이 닫혀요.</div>
                 <S.ButtonSet>


### PR DESCRIPTION
## 개요
외부 영역 클릭시에만 모달이 닫히도록 수정

## 작업사항
- 모달창 외부 영역 클릭시에만 모달창이 닫혀야 하고, 모달창 클릭 시에는 닫히면 안됨
- 모달창 클릭 시 닫히는 현상 수정

## 변경로직
- `onClick={openMiniModalHandler}`