### PR TITLE
Fix 모달 오픈 시 셀렉트박스 활성화되는 문제 수정

### DIFF
--- a/src/styles/SelectStyle.jsx
+++ b/src/styles/SelectStyle.jsx
@@ -4,7 +4,7 @@ export const SelectLayout = styled.div`
     border: 3px solid rgb(221, 221, 221);
     height: 200px;
     overflow: hidden;
-    position: relative;
+    /* position: relative; */
     margin-top: 50px;
 `
 


### PR DESCRIPTION
## 개요
모달창 오픈 시 셀렉트박스 비활성화되도록 수정

## 작업사항
- 모달창 오픈 시 외부영역은 비활성화되어야 하는데, 셀렉트박스가 활성화되는 문제
- 셀렉트박스 position 수정

## 변경로직
- `/* position: relative; */`